### PR TITLE
Added a version of scrollTo() that scrolls to an area

### DIFF
--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayoutApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayoutApi.kt
@@ -15,7 +15,13 @@ import ovh.plrapps.mapcompose.ui.layout.Fit
 import ovh.plrapps.mapcompose.ui.layout.Forced
 import ovh.plrapps.mapcompose.ui.layout.MinimumScaleMode
 import ovh.plrapps.mapcompose.ui.state.MapState
-import ovh.plrapps.mapcompose.utils.*
+import ovh.plrapps.mapcompose.utils.AngleDegree
+import ovh.plrapps.mapcompose.utils.Point
+import ovh.plrapps.mapcompose.utils.rotate
+import ovh.plrapps.mapcompose.utils.rotateCenteredX
+import ovh.plrapps.mapcompose.utils.rotateCenteredY
+import ovh.plrapps.mapcompose.utils.scaleAxis
+import ovh.plrapps.mapcompose.utils.toRad
 import ovh.plrapps.mapcompose.utils.withRetry
 import kotlin.math.min
 
@@ -211,12 +217,17 @@ suspend fun MapState.scrollTo(
         val centerX = (area.xLeft + area.xRight) / 2
         val centerY = (area.yTop + area.yBottom) / 2
 
-        val areaWidth = fullWidth * (area.xRight - area.xLeft)
+        val xAxisScale = fullHeight / fullWidth.toDouble()
+        val normalizedArea = area.scaleAxis(1 / xAxisScale)
+        val rotatedNormalizedArea = normalizedArea.rotate(Point(centerX / xAxisScale, centerY), -rotation.toRad())
+        val rotatedArea = rotatedNormalizedArea.scaleAxis(xAxisScale)
+
+        val areaWidth = fullWidth * (rotatedArea.xRight - rotatedArea.xLeft)
         val availableViewportWidth = layoutSize.width * (1 - padding.x)
         val areaWidthLayoutFraction = areaWidth / availableViewportWidth
         val horizontalScale = 1 / areaWidthLayoutFraction
 
-        val areaHeight = fullHeight * (area.yBottom - area.yTop)
+        val areaHeight = fullHeight * (rotatedArea.yBottom - rotatedArea.yTop)
         val availableViewportHeight = layoutSize.height * (1 - padding.y)
         val areaHeightLayoutFraction = areaHeight / availableViewportHeight
         val verticalScale = 1 / areaHeightLayoutFraction

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/BoundingBoxUtils.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/BoundingBoxUtils.kt
@@ -1,0 +1,24 @@
+package ovh.plrapps.mapcompose.utils
+
+import ovh.plrapps.mapcompose.api.BoundingBox
+
+fun BoundingBox.scaleAxis(xAxisMultiplier: Double): BoundingBox {
+    return BoundingBox(xLeft * xAxisMultiplier, yTop, xRight * xAxisMultiplier, yBottom)
+}
+
+fun BoundingBox.rotate(center: Point, angle: AngleRad): BoundingBox {
+    val topLeft = Point(xLeft, yTop)
+    val topRight = Point(xRight, yTop)
+    val bottomLeft = Point(xLeft, yBottom)
+    val bottomRight = Point(xRight, yBottom)
+
+    val points = listOf(topLeft, topRight, bottomLeft, bottomRight)
+    val rotatedPoints = rotateCentered(points, center, angle)
+
+    val left = rotatedPoints.minOf { it.x }
+    val top = rotatedPoints.minOf { it.y }
+    val right = rotatedPoints.maxOf { it.x }
+    val bottom = rotatedPoints.maxOf { it.y }
+
+    return BoundingBox(left, top, right, bottom)
+}

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/BoundingBoxUtils.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/BoundingBoxUtils.kt
@@ -2,11 +2,11 @@ package ovh.plrapps.mapcompose.utils
 
 import ovh.plrapps.mapcompose.api.BoundingBox
 
-fun BoundingBox.scaleAxis(xAxisMultiplier: Double): BoundingBox {
+internal fun BoundingBox.scaleAxis(xAxisMultiplier: Double): BoundingBox {
     return BoundingBox(xLeft * xAxisMultiplier, yTop, xRight * xAxisMultiplier, yBottom)
 }
 
-fun BoundingBox.rotate(center: Point, angle: AngleRad): BoundingBox {
+internal fun BoundingBox.rotate(center: Point, angle: AngleRad): BoundingBox {
     val topLeft = Point(xLeft, yTop)
     val topRight = Point(xRight, yTop)
     val bottomLeft = Point(xLeft, yBottom)

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/Point.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/Point.kt
@@ -1,0 +1,3 @@
+package ovh.plrapps.mapcompose.utils
+
+data class Point(val x: Double, val y: Double)

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/RotationUtils.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/utils/RotationUtils.kt
@@ -26,6 +26,22 @@ fun rotateY(x: Double, y: Double, angleRad: AngleRad): Double {
     return x * sin(angleRad) + y * cos(angleRad)
 }
 
+fun rotateCentered(points: List<Point>, center: Point, angleRad: AngleRad): List<Point> {
+    return points.map { rotateCentered(it, center, angleRad) }
+}
+
+fun rotateCentered(point: Point, center: Point, angleRad: AngleRad): Point {
+    return Point(rotateCenteredX(point, center, angleRad), rotateCenteredY(point, center, angleRad))
+}
+
+fun rotateCenteredX(point: Point, center: Point, angleRad: AngleRad): Double {
+    return rotateCenteredX(point.x, point.y, center.x, center.y, angleRad)
+}
+
+fun rotateCenteredY(point: Point, center: Point, angleRad: AngleRad): Double {
+    return rotateCenteredY(point.x, point.y, center.x, center.y, angleRad)
+}
+
 fun rotateCenteredX(x: Double, y: Double, centerX: Double, centerY: Double, angleRad: AngleRad): Double {
     return centerX + (x - centerX) * cos(angleRad) - (y - centerY) * sin(angleRad)
 }


### PR DESCRIPTION
A new version of `scrollTo()` that scrolls to an area defined by a `BoundingBox`. For example, if you want to show a city on a map so that it's zoomed in on the city as much as possible while still keeping the entire city in view. It also includes an optional `padding` parameter in case we don't want the area to occupy the viewport edge to edge.