### PR TITLE
Made map background color configurable

### DIFF
--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
@@ -2,8 +2,9 @@
 
 package ovh.plrapps.mapcompose.api
 
-import ovh.plrapps.mapcompose.core.ColorFilterProvider
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import ovh.plrapps.mapcompose.core.ColorFilterProvider
 import ovh.plrapps.mapcompose.ui.state.MapState
 
 /**
@@ -29,4 +30,12 @@ fun MapState.disableFadeIn() {
  */
 fun MapState.setColorFilterProvider(provider: ColorFilterProvider) {
     tileCanvasState.colorFilterProvider = provider
+}
+
+/**
+ * Sets the background color visible before tiles are loaded or when the canvas outside of the
+ * map area is in view.
+ */
+fun MapState.setMapBackground(color: Color) {
+    mapBackground = color
 }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/MapUI.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/MapUI.kt
@@ -1,5 +1,6 @@
 package ovh.plrapps.mapcompose.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -21,7 +22,7 @@ fun MapUI(
     val pathState = state.pathState
 
     ZoomPanRotate(
-        modifier = modifier.clipToBounds(),
+        modifier = modifier.clipToBounds().background(state.mapBackground),
         gestureListener = zoomPRState,
         layoutSizeChangeListener = zoomPRState,
         padding = zoomPRState.padding,

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
@@ -2,6 +2,8 @@ package ovh.plrapps.mapcompose.ui.state
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.SendChannel
 import ovh.plrapps.mapcompose.core.TileStreamProvider
@@ -56,6 +58,7 @@ class MapState(
     internal val tileSize by mutableStateOf(tileSize)
     internal var stateChangeListener: (MapState.() -> Unit)? = null
     internal var touchDownCb: (() -> Unit)? = null
+    internal var mapBackground by mutableStateOf(Color.White)
 
     /**
      * Cancels all internal tasks.

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/view/TileCanvas.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/view/TileCanvas.kt
@@ -30,7 +30,6 @@ internal fun TileCanvas(
     Canvas(
         modifier = modifier
             .fillMaxSize()
-            .background(Color.White)
     ) {
         withTransform({
             /* Geometric transformations seem to be applied in reversed order of declaration */


### PR DESCRIPTION
When the map is zoomed out out of bounds, or the tiles have not loaded in yet, there is a white background color visible. This PR makes the color configurable (but still defaults to white).