### PR TITLE
Fixed tile borders being visible (Fixes #5)

### DIFF
--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
@@ -30,3 +30,11 @@ fun MapState.disableFadeIn() {
 fun MapState.setColorFilterProvider(provider: ColorFilterProvider) {
     tileCanvasState.colorFilterProvider = provider
 }
+
+/**
+ * Enables a workaround preventing tiles from being drawn not completely touching each other, making
+ * the map background visible in-between tiles. The workaround incurs a slight performance cost.
+ */
+fun MapState.setTileBleedWorkaroundEnabled(enabled: Boolean) {
+    isTileBleedWorkaroundEnabled = enabled
+}

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/MapUI.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/MapUI.kt
@@ -33,7 +33,8 @@ fun MapUI(
             tileSize = state.tileSize,
             alphaTick = state.tileCanvasState.alphaTick,
             colorFilterProvider = state.tileCanvasState.colorFilterProvider,
-            tilesToRender = state.tileCanvasState.tilesToRender
+            tilesToRender = state.tileCanvasState.tilesToRender,
+            isTileBleedWorkaroundEnabled = state.isTileBleedWorkaroundEnabled
         )
 
         MarkerComposer(

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
@@ -2,6 +2,7 @@ package ovh.plrapps.mapcompose.ui.state
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.SendChannel
 import ovh.plrapps.mapcompose.core.TileStreamProvider
@@ -56,6 +57,7 @@ class MapState(
     internal val tileSize by mutableStateOf(tileSize)
     internal var stateChangeListener: (MapState.() -> Unit)? = null
     internal var touchDownCb: (() -> Unit)? = null
+    internal var isTileBleedWorkaroundEnabled by mutableStateOf(false)
 
     /**
      * Cancels all internal tasks.

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/view/TileCanvas.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/view/TileCanvas.kt
@@ -44,26 +44,36 @@ internal fun TileCanvas(
             )
             scale(scale = zoomPRState.scale, Offset.Zero)
         }) {
-            for (tile in tilesToRender) {
-                val scaleForLevel = visibleTilesResolver.getScaleForLevel(tile.zoom)
-                    ?: continue
-                val tileScaled = (tileSize / scaleForLevel).toInt()
-                val l = tile.col * tileScaled
-                val t = tile.row * tileScaled
+            for (withOverlap in listOf(true, false)) {
+                for (tile in tilesToRender) {
+                    val scaleForLevel = visibleTilesResolver.getScaleForLevel(tile.zoom)
+                        ?: continue
+                    val tileScaled = (tileSize / scaleForLevel).toInt()
+                    val l = tile.col * tileScaled
+                    val t = tile.row * tileScaled
 
-                val destOffset = IntOffset(l, t)
-                val destSize = IntSize(tileScaled, tileScaled)
+                    val destOffset = if (withOverlap) {
+                        IntOffset(l - 1, t - 1)
+                    } else {
+                        IntOffset(l, t)
+                    }
+                    val destSize = if (withOverlap) {
+                        IntSize(tileScaled + 2, tileScaled + 2)
+                    } else {
+                        IntSize(tileScaled, tileScaled)
+                    }
 
-                val colorFilter = colorFilterProvider?.getColorFilter(tile.row, tile.col, tile.zoom)
+                    val colorFilter = colorFilterProvider?.getColorFilter(tile.row, tile.col, tile.zoom)
 
-                drawImage(
-                    tile.bitmap.asImageBitmap(), dstOffset = destOffset, dstSize = destSize,
-                    alpha = tile.alpha, colorFilter = colorFilter
-                )
+                    drawImage(
+                        tile.bitmap.asImageBitmap(), dstOffset = destOffset, dstSize = destSize,
+                        alpha = tile.alpha, colorFilter = colorFilter
+                    )
 
-                /* If a tile isn't fully opaque, increase its alpha state by the alpha tick */
-                if (tile.alpha < 1f) {
-                    tile.alpha = (tile.alpha + alphaTick).coerceAtMost(1f)
+                    /* If a tile isn't fully opaque, increase its alpha state by the alpha tick */
+                    if (tile.alpha < 1f) {
+                        tile.alpha = (tile.alpha + alphaTick).coerceAtMost(1f)
+                    }
                 }
             }
         }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/view/TileCanvas.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/view/TileCanvas.kt
@@ -25,7 +25,8 @@ internal fun TileCanvas(
     tileSize: Int,
     alphaTick: Float,
     colorFilterProvider: ColorFilterProvider?,
-    tilesToRender: List<Tile>
+    tilesToRender: List<Tile>,
+    isTileBleedWorkaroundEnabled: Boolean
 ) {
     Canvas(
         modifier = modifier
@@ -44,7 +45,8 @@ internal fun TileCanvas(
             )
             scale(scale = zoomPRState.scale, Offset.Zero)
         }) {
-            for (withOverlap in listOf(true, false)) {
+            val drawingPasses = if (isTileBleedWorkaroundEnabled) listOf(true, false) else listOf(false)
+            for (withOverlap in drawingPasses) {
                 for (tile in tilesToRender) {
                     val scaleForLevel = visibleTilesResolver.getScaleForLevel(tile.zoom)
                         ?: continue


### PR DESCRIPTION
Adds drawing another layer of tiles with slightly overlapping sizes under the main layer of tiles, so they fill-in the visible spaces between tiles. (Fixes #5)

Regarding performance, this is obviously not great since tile drawing has to be done twice. However in my testing both on an emulator and on a physical device the drawing time still very rarely goes above 1-2ms per frame, so it's still perfectly fluid.

This is a workaround, it would definitely be better to actually fix the underlying issue, but since the underlying issue is in Compose or framework code, we likely cannot fix it in this codebase. I'd be happy to be proven wrong though. In the meantime, this does work and completely fixes the issue.

Even so, I have added it behind a configuration option which is disabled by default, so nothing is done differently unless the user explicitly enables the workaround.