### PR TITLE
Fixes rotation direction for smooth rotations

### DIFF
--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
@@ -152,9 +152,13 @@ internal class ZoomPanRotateState(
         /* We don't have to stop scrolling animation while doing that */
         return invokeAndCheckSuccess {
             val currRotation = this@ZoomPanRotateState.rotation
+            var targetAngle = (angle % 360)
+            if (abs(targetAngle - currRotation) > 180) {
+                targetAngle += if (targetAngle > currRotation) -360 else 360
+            }
             apiAnimatable.snapTo(0f)
             apiAnimatable.animateTo(1f, animationSpec) {
-                setRotation(lerp(currRotation, angle, value))
+                setRotation(lerp(currRotation, targetAngle, value))
             }
         }
     }


### PR DESCRIPTION
Currently when using `rotateTo` the map never rotates through the 0° point. This means that a rotation from 355° to 5°, which should be a small 10° adjustment is instead performing a -350° barrel roll, which although amusing is not what one would expect.