### PR TITLE
Minor v2 fixes

### DIFF
--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayerApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayerApi.kt
@@ -130,7 +130,7 @@ fun MapState.reorderLayers(layerIds: List<String>) {
  * Remove all layers.
  */
 fun MapState.removeAllLayers() {
-    setLayers(listOf())
+    setLayers(emptyList())
 }
 
 /**

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayerApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/LayerApi.kt
@@ -154,8 +154,8 @@ fun MapState.removeLayer(layerId: String) {
 }
 
 /**
- * Dynamically update the opacity of a layer. If the layer is the lowest one or the only one, this
- * API is a no-op.
+ * Dynamically update the opacity of a layer. If the layer is the lowest one or the only one, the
+ * new opacity won't have effect until a layer is added below it.
  */
 fun MapState.setLayerOpacity(layerId: String, opacity: Float) {
     tileCanvasState.layerFlow.value.firstOrNull { it.id == layerId}?.apply {


### PR DESCRIPTION
- Changed `listOf()` to `emptyList()`. This is more idiomatic and performant (although it doesn't matter here).
- Updated the `setLayerOpacity()` documentation. It's not true that the API is a no-op, since the opacity does change and the changed opacity can be used in the future.