### PR TITLE
Updates to InitialValues

### DIFF
--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
@@ -67,12 +67,11 @@ fun MapState.setBitmapFilteringEnabled(predicate: (state: MapState) -> Boolean) 
  * Virtually increase the size of the screen by a padding in pixel amount.
  * With the appropriate value, this can be used to produce a seamless tile loading effect.
  */
-fun MapState.setPadding(pixels: Int) {
+fun MapState.setPreloadingPadding(pixels: Int) {
     scope.launch {
-        padding = pixels.coerceAtLeast(0)
+        preloadingPadding = pixels.coerceAtLeast(0)
         renderVisibleTilesThrottled()
     }
-
 }
 
 /**

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/RenderApi.kt
@@ -66,10 +66,12 @@ fun MapState.setBitmapFilteringEnabled(predicate: (state: MapState) -> Boolean) 
 /**
  * Virtually increase the size of the screen by a padding in pixel amount.
  * With the appropriate value, this can be used to produce a seamless tile loading effect.
+ *
+ * @param padding in pixels
  */
-fun MapState.setPreloadingPadding(pixels: Int) {
+fun MapState.setPreloadingPadding(padding: Int) {
     scope.launch {
-        preloadingPadding = pixels.coerceAtLeast(0)
+        preloadingPadding = padding.coerceAtLeast(0)
         renderVisibleTilesThrottled()
     }
 }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/Defaults.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/Defaults.kt
@@ -1,6 +1,0 @@
-package ovh.plrapps.mapcompose.ui.state
-
-import ovh.plrapps.mapcompose.ui.layout.Fit
-
-internal const val maxScaleDefault = 2f
-internal val minimumScaleModeDefault = Fit

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
@@ -9,11 +9,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import ovh.plrapps.mapcompose.api.rotateTo
+import ovh.plrapps.mapcompose.api.rotation
 import ovh.plrapps.mapcompose.core.Viewport
 import ovh.plrapps.mapcompose.core.VisibleTilesResolver
 import ovh.plrapps.mapcompose.core.throttle
 import ovh.plrapps.mapcompose.ui.layout.Fit
 import ovh.plrapps.mapcompose.ui.layout.MinimumScaleMode
+import ovh.plrapps.mapcompose.utils.AngleDegree
 import ovh.plrapps.mapcompose.utils.toRad
 
 /**
@@ -23,58 +26,59 @@ import ovh.plrapps.mapcompose.utils.toRad
  * @param levelCount The number of levels in the pyramid.
  * @param fullWidth The width in pixels of the map at scale 1f.
  * @param fullHeight The height in pixels of the map at scale 1f.
- * @param tileSize The size in pixels of tiles, which are expected to be squared. Defaults to 256.
- * @param workerCount The thread count used to fetch tiles. Defaults to the number of cores minus
- * one, which works well for tiles in the file system or in a local database. However, that number
- * should be increased to 16 or more for remote tiles (HTTP requests).
- * @param highFidelityColors By default, bitmaps are loaded using ARGB_8888, which is best suited
- * for most usages. However, if you're only loading images without alpha channel and high fidelity
- * color isn't a requirement, RGB_565 can be used instead for less memory usage.
- * Beware, however, that some types of images can't be loaded using RGB_565 (such as PNGs with alpha
- * channel). Unless you know what you're doing, let this parameter to true.
  */
 class MapState(
     levelCount: Int,
     fullWidth: Int,
     fullHeight: Int,
-    tileSize: Int = 256,
-    workerCount: Int = Runtime.getRuntime().availableProcessors() - 1,
-    highFidelityColors: Boolean = true,
-    initialValues: InitialValues? = null
+    initialValues: InitialValues = InitialValues()
 ) : ZoomPanRotateStateListener {
     internal val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    internal val zoomPanRotateState = ZoomPanRotateState(fullWidth, fullHeight, this)
+    internal val zoomPanRotateState = ZoomPanRotateState(
+        fullWidth = fullWidth,
+        fullHeight = fullHeight,
+        stateChangeListener = this,
+        minimumScaleMode = initialValues.minimumScaleMode,
+        maxScale = initialValues.maxScale,
+        scale = initialValues.scale,
+        rotation = initialValues.rotation,
+        isRotationEnabled = initialValues.isRotationEnabled
+    )
     internal val markerState = MarkerState()
     internal val pathState = PathState()
     internal val visibleTilesResolver =
-        VisibleTilesResolver(levelCount, fullWidth, fullHeight, tileSize) {
+        VisibleTilesResolver(
+            levelCount = levelCount,
+            fullWidth = fullWidth,
+            fullHeight = fullHeight,
+            tileSize = initialValues.tileSize,
+            magnifyingFactor = initialValues.magnifyingFactor
+        ) {
             zoomPanRotateState.scale
         }
     internal val tileCanvasState = TileCanvasState(
         scope,
-        tileSize,
+        initialValues.tileSize,
         visibleTilesResolver,
-        workerCount,
-        highFidelityColors
+        initialValues.workerCount,
+        initialValues.highFidelityColors
     )
 
     private val throttledTask = scope.throttle(wait = 18) {
         renderVisibleTiles()
     }
     private val viewport = Viewport()
-    internal var padding: Int = 0
-    internal val tileSize by mutableStateOf(tileSize)
+    internal var preloadingPadding: Int = initialValues.preloadingPadding
+    internal val tileSize by mutableStateOf(initialValues.tileSize)
     internal var stateChangeListener: (MapState.() -> Unit)? = null
     internal var touchDownCb: (() -> Unit)? = null
     internal var mapBackground by mutableStateOf(Color.White)
-    internal var isFilteringBitmap: () -> Boolean by mutableStateOf({ true })
-    private var initialValues: InitialValues? = null
-
-    init {
-        this.initialValues = initialValues
-        if (initialValues != null) {
-            applyStaticInitialValues(initialValues)
-        }
+    internal var isFilteringBitmap: () -> Boolean by mutableStateOf(
+        { initialValues.isFilteringBitmap(this) }
+    )
+    private var consumeDynamicInitialValues: () -> Unit = {
+        consumeDynamicInitialValues = {}
+        applyDynamicInitialValues(initialValues)
     }
 
     /**
@@ -87,11 +91,7 @@ class MapState(
     }
 
     override fun onStateChanged() {
-        /* Consume initial values */
-        initialValues?.also {
-            initialValues = null
-            applyDynamicInitialValues(it)
-        }
+        consumeDynamicInitialValues()
 
         renderVisibleTilesThrottled()
         stateChangeListener?.invoke(this)
@@ -115,37 +115,13 @@ class MapState(
     }
 
     private fun updateViewport(): Viewport {
-        val padding = padding
+        val padding = preloadingPadding
         return viewport.apply {
             left = zoomPanRotateState.scrollX.toInt() - padding - zoomPanRotateState.padding.x
             top = zoomPanRotateState.scrollY.toInt() - padding - zoomPanRotateState.padding.y
             right = left + zoomPanRotateState.layoutSize.width + padding * 2
             bottom = top + zoomPanRotateState.layoutSize.height + padding * 2
             angleRad = zoomPanRotateState.rotation.toRad()
-        }
-    }
-
-    /**
-     * Apply "static" initial values - e.g, those which don't depend on the layout size.
-     * These are the scale, rotation, minimum scale mode, and magnifying factor.
-     */
-    private fun applyStaticInitialValues(initialValues: InitialValues) {
-        visibleTilesResolver.magnifyingFactor = initialValues.magnifyingFactor
-
-        initialValues.minimumScaleMode?.also {
-            zoomPanRotateState.minimumScaleMode = it
-        }
-
-        initialValues.maxScale?.also {
-            zoomPanRotateState.maxScale = it
-        }
-
-        initialValues.scale?.also { scale ->
-            zoomPanRotateState.setScale(scale, notify = false)
-        }
-
-        initialValues.rotation?.also { rotation ->
-            zoomPanRotateState.setRotation(rotation, notify = false)
         }
     }
 
@@ -184,14 +160,20 @@ class InitialValues {
     internal var x = 0.0
     internal var y = 0.0
     internal var screenOffset: Offset = Offset.Zero
-    internal var scale: Float? = null
-    internal var minimumScaleMode: MinimumScaleMode? = null
-    internal var maxScale: Float? = null
-    internal var rotation: Float? = null
+    internal var scale: Float = 1f
+    internal var minimumScaleMode: MinimumScaleMode = Fit
+    internal var maxScale: Float = 2f
+    internal var rotation: AngleDegree = 0f
     internal var magnifyingFactor = 0
+    internal var tileSize: Int = 256
+    internal var workerCount: Int = Runtime.getRuntime().availableProcessors() - 1
+    internal var highFidelityColors: Boolean = true
+    internal var isRotationEnabled: Boolean = false
+    internal var preloadingPadding: Int = 0
+    internal var isFilteringBitmap: (MapState) -> Boolean = { true }
 
     /**
-     * Init the scroll position. Defaults to centering on the provided scroll destination.
+     * Initial scroll position. Defaults to centering on the provided scroll destination.
      *
      * @param x The normalized X position on the map, in range [0..1]
      * @param y The normalized Y position on the map, in range [0..1]
@@ -199,41 +181,108 @@ class InitialValues {
      * Offset(-0.5f, -0.5f), so moving the screen by half the width left and by half the height top,
      * effectively centering on the scroll destination.
      */
-    fun scroll(x: Double, y: Double, screenOffset: Offset = Offset(-0.5f, -0.5f)): InitialValues {
+    fun scroll(x: Double, y: Double, screenOffset: Offset = Offset(-0.5f, -0.5f)) = apply {
         this.screenOffset = screenOffset
         this.x = x
         this.y = y
-        return this
     }
 
     /**
-     * Set the initial scale. If necessary, the initial [MinimumScaleMode] can be specified (the
-     * default is [Fit]).
+     * Initial scale. Defaults to 1f.
      */
-    fun scale(
-        scale: Float,
-        minimumScaleMode: MinimumScaleMode = minimumScaleModeDefault,
-        maxScale: Float = maxScaleDefault
-    ): InitialValues {
-        this.minimumScaleMode = minimumScaleMode
-        this.maxScale = maxScale
+    fun scale(scale: Float) = apply {
         this.scale = scale
-        return this
     }
 
-    fun rotation(rotation: Float): InitialValues {
+    /**
+     * [MinimumScaleMode]. Defaults to [Fit].
+     */
+    fun minimumScaleMode(minimumScaleMode: MinimumScaleMode) = apply {
+        this.minimumScaleMode = minimumScaleMode
+    }
+
+    /**
+     * Maximum allowed scale. Defaults to 2f.
+     */
+    fun maxScale(maxScale: Float) = apply {
+        this.maxScale = maxScale
+    }
+
+    /**
+     * Initial rotation. Defaults to 0° (no rotation).
+     */
+    fun rotation(rotation: AngleDegree) = apply {
         this.rotation = rotation
-        return this
     }
 
     /**
      * Alters the level at which tiles are picked for a given scale. By default, the level
      * immediately higher (in index) is picked, to avoid sub-sampling. This corresponds to a
-     * [magnifyingFactor] of 0. The value 1 will result in picking the current level at a given scale,
-     * which will be at a relative scale between 1.0 and 2.0
+     * [magnifyingFactor] of 0. The value 1 will result in picking the current level at a given
+     * scale, which will be at a relative scale between 1.0 and 2.0
      */
-    fun magnifyingFactor(magnifyingFactor: Int): InitialValues {
+    fun magnifyingFactor(magnifyingFactor: Int) = apply {
         this.magnifyingFactor = magnifyingFactor.coerceAtLeast(0)
-        return this
+    }
+
+    /**
+     * The size in pixels of tiles, which are expected to be square. Defaults to 256.
+     */
+    fun tileSize(tileSize: Int) = apply {
+        this.tileSize = tileSize
+    }
+
+    /**
+     * The thread count used to fetch tiles. Defaults to the number of cores minus one, which
+     * works well for tiles in the file system or in a local database. However, that number
+     * should be increased to 16 or more for remote tiles (HTTP requests).
+     */
+    fun workerCount(workerCount: Int) = apply {
+        this.workerCount = workerCount
+    }
+
+    /**
+     * By default, bitmaps are loaded using ARGB_8888, which is best suited for most usages.
+     * However, if you're only loading images without alpha channel and high fidelity color isn't
+     * a requirement, RGB_565 can be used instead for less memory usage (by setting this to false).
+     * Beware, however, that some types of images can't be loaded using RGB_565 (such as PNGs with
+     * alpha channel). Unless you know what you're doing, let this parameter be true.
+     */
+    fun highFidelityColors(enabled: Boolean) = apply {
+        this.highFidelityColors = enabled
+    }
+
+    /**
+     * Controls if the map can be rotated by user gestures. The map can always be programmatically
+     * rotated using APIs such as [rotateTo] or [rotation].
+     */
+    fun rotationEnabled(enabled: Boolean) = apply {
+        this.isRotationEnabled = enabled
+    }
+
+    /**
+     * By default, only visible tiles are loaded. By adding a preloadingPadding additional tiles
+     * will be loaded, which can be used to produce a seamless tile loading effect.
+     */
+    fun preloadingPadding(preloadingPadding: Int) = apply {
+        this.preloadingPadding = preloadingPadding.coerceAtLeast(0)
+    }
+
+    /**
+     * Controls whether Bitmap filtering is enabled when drawing tiles. This is enabled by default.
+     * Disabling it is useful to achieve nearest-neighbor scaling, for cases when the art style of
+     * the displayed image benefits from it.
+     * @see [android.graphics.Paint.setFilterBitmap]
+     */
+    fun bitmapFilteringEnabled(enabled: Boolean) = apply {
+        bitmapFilteringEnabled { enabled }
+    }
+
+    /**
+     * A version of [bitmapFilteringEnabled] which allows for dynamic control of bitmap filtering
+     * depending on the current [MapState].
+     */
+    fun bitmapFilteringEnabled(predicate: (state: MapState) -> Boolean) = apply {
+        isFilteringBitmap = predicate
     }
 }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
@@ -19,7 +19,12 @@ import kotlin.math.*
 internal class ZoomPanRotateState(
     val fullWidth: Int,
     val fullHeight: Int,
-    private val stateChangeListener: ZoomPanRotateStateListener
+    private val stateChangeListener: ZoomPanRotateStateListener,
+    minimumScaleMode: MinimumScaleMode,
+    maxScale: Float,
+    scale: Float,
+    rotation: AngleDegree,
+    internal var isRotationEnabled: Boolean
 ) : GestureListener, LayoutSizeChangeListener {
     private var scope: CoroutineScope? = null
     private var onLayoutContinuations = mutableListOf<Continuation<Unit>>()
@@ -38,17 +43,15 @@ internal class ZoomPanRotateState(
         }
     }
 
-    internal var minimumScaleMode: MinimumScaleMode = minimumScaleModeDefault
+    internal var minimumScaleMode: MinimumScaleMode = minimumScaleMode
         set(value) {
             field = value
             recalculateMinScale()
         }
 
-    internal var isRotationEnabled = false
-
     /* Only source of truth. Don't mutate directly, use appropriate setScale(), setRotation(), etc. */
-    internal var scale by mutableStateOf(1f)
-    internal var rotation: AngleDegree by mutableStateOf(0f)
+    internal var scale by mutableStateOf(scale)
+    internal var rotation: AngleDegree by mutableStateOf(rotation)
     internal var scrollX by mutableStateOf(0f)
     internal var scrollY by mutableStateOf(0f)
 
@@ -63,7 +66,7 @@ internal class ZoomPanRotateState(
             setScale(scale)
         }
 
-    var maxScale = maxScaleDefault
+    var maxScale = maxScale
         set(value) {
             field = value
             setScale(scale)

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
@@ -23,8 +23,7 @@ internal class ZoomPanRotateState(
     minimumScaleMode: MinimumScaleMode,
     maxScale: Float,
     scale: Float,
-    rotation: AngleDegree,
-    internal var isRotationEnabled: Boolean
+    rotation: AngleDegree
 ) : GestureListener, LayoutSizeChangeListener {
     private var scope: CoroutineScope? = null
     private var onLayoutContinuations = mutableListOf<Continuation<Unit>>()
@@ -48,6 +47,8 @@ internal class ZoomPanRotateState(
             field = value
             recalculateMinScale()
         }
+
+    internal var isRotationEnabled = false
 
     /* Only source of truth. Don't mutate directly, use appropriate setScale(), setRotation(), etc. */
     internal var scale by mutableStateOf(scale)


### PR DESCRIPTION
- Deleted the Defaults.kt file, defaults very defined in multiple places: nulls in `InitialValues`, default method parameters in methods in `InitialValues`, and initializations where the values are used. Instead, I moved all initial values to `InitialValues`. Instead of `InitialValues` being nullable, a default one is always created, and is the single source of truth for initial values.
- Removed `applyStaticInitialValues()` since now they are applied directly.
- Moved `tileSize`, `workerCount` and `highFidelityColors` to `InitialValues`. I think it makes sense to have all non-required parameters in the same place, without having to define some in one way and others in another.
- Removed the `initialValues` variable which was being set to null after use. Now it's a function that disables itself.
- Changed the `return this` in every `InitialValues` method to using `apply`, which is more idiomatic and cleaner.
- Renamed `padding` to `preloadingPadding` to be clearer about what it does (could be confused with `Modifier.padding()`)
- Added `rotationEnabled()`, `preloadingPadding()`, and `bitmapFilteringEnabled()` to `InitialValues`. This should make the `MapState` initialization cleaner, because all settings can be set in `InitialValues`, rather than having to mutate it after creation to continue the setup.