### PR TITLE
Expose onDoubleClick() callback

### DIFF
--- a/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/SimpleDemoVM.kt
+++ b/demo/src/main/java/ovh/plrapps/mapcompose/demo/viewmodels/SimpleDemoVM.kt
@@ -2,8 +2,15 @@ package ovh.plrapps.mapcompose.demo.viewmodels
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
 import ovh.plrapps.mapcompose.api.addLayer
 import ovh.plrapps.mapcompose.api.enableRotation
+import ovh.plrapps.mapcompose.api.maxScale
+import ovh.plrapps.mapcompose.api.minScale
+import ovh.plrapps.mapcompose.api.onDoubleTap
+import ovh.plrapps.mapcompose.api.scale
+import ovh.plrapps.mapcompose.api.scrollTo
 import ovh.plrapps.mapcompose.api.shouldLoopScale
 import ovh.plrapps.mapcompose.demo.providers.makeTileStreamProvider
 import ovh.plrapps.mapcompose.ui.state.MapState
@@ -17,5 +24,17 @@ class SimpleDemoVM(application: Application) : AndroidViewModel(application) {
         addLayer(tileStreamProvider)
         shouldLoopScale = true
         enableRotation()
+        /**
+         * Example [onDoubleTap] callback that implements a different zoom behavior
+         */
+        onDoubleTap { x, y ->
+            viewModelScope.launch {
+                if(scale < maxScale) {
+                    scrollTo(x, y, maxScale)
+                } else {
+                    scrollTo(x, y, minScale)
+                }
+            }
+        }
     }
 }

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/GesturesApi.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/api/GesturesApi.kt
@@ -86,6 +86,16 @@ fun MapState.onTap(tapCb: (x: Double, y: Double) -> Unit) {
 }
 
 /**
+ * Registers a callback for double-tap gestures. The callback is invoked with the relative
+ * coordinates of the double-tapped point on the map.
+ *
+ * When a callback is registered, it overrides the default double-tap zoom behavior.
+ */
+fun MapState.onDoubleTap(doubleTapCb: (x: Double, y: Double) -> Unit) {
+    this.doubleTapCb = doubleTapCb
+}
+
+/**
  * Registers a callback for long press gestures. The callback is invoked with the relative coordinates
  * of the pressed point on the map.
  */

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/MapState.kt
@@ -88,6 +88,7 @@ class MapState(
     internal var stateChangeListener: (MapState.() -> Unit)? = null
     internal var touchDownCb: (() -> Unit)? = null
     internal var tapCb: LayoutTapCb? = null
+    internal var doubleTapCb: LayoutTapCb? = null
     internal var longPressCb: LayoutTapCb? = null
     internal var mapBackground by mutableStateOf(Color.Transparent)
     internal var isFilteringBitmap: () -> Boolean by mutableStateOf(
@@ -131,6 +132,13 @@ class MapState(
 
     override fun onTap(x: Double, y: Double) {
         tapCb?.invoke(x, y)
+    }
+
+    override fun onDoubleTap(x: Double, y: Double): Boolean {
+        return doubleTapCb?.let {
+            it(x, y)
+            true
+        } ?: false
     }
 
     override fun detectsTap(): Boolean = tapCb != null

--- a/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
+++ b/mapcompose/src/main/java/ovh/plrapps/mapcompose/ui/state/ZoomPanRotateState.kt
@@ -483,6 +483,11 @@ internal class ZoomPanRotateState(
     }
 
     override fun onDoubleTap(focalPt: Offset) {
+        val isHandled = offsetToRelative(focalPt) { x, y ->
+            stateChangeListener.onDoubleTap(x, y)
+        }
+        if (isHandled) return
+
         if (!isZoomingEnabled) return
 
         val destScale = (
@@ -717,6 +722,7 @@ interface ZoomPanRotateStateListener {
     fun onPress()
     fun onLongPress(x: Double, y: Double)
     fun onTap(x: Double, y: Double)
+    fun onDoubleTap(x: Double, y: Double): Boolean
     fun detectsTap(): Boolean
     fun detectsLongPress(): Boolean
     fun interceptsTap(x: Double, y: Double, xPx: Int, yPx: Int): Boolean


### PR DESCRIPTION
This exposes an onDoubleClick() callback function allowing the user to override the default functionality of MapCompose.

This is a proposed solution to #149

I have included a small demo example, however this can be removed before merging.